### PR TITLE
Create image, build and publish

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,49 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ "main" ]
+    tags:
+      - "*.*.*"
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    # https://docs.docker.com/build/ci/github-actions/manage-tags-labels/
+    - name: Docker meta
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        # list of Docker images to use as base name for tags
+        images: |
+          hackinsdn/modsecurity-crs
+        # generate Docker tags based on the following events/attributes
+        tags: |
+          type=ref,event=branch
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}}
+          type=semver,pattern={{major}}
+          type=sha
+
+    # https://github.com/docker/setup-buildx-action
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    # https://github.com/docker/login-action
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    # https://github.com/marketplace/actions/build-and-push-docker-images
+    - name: Build and push
+      uses: docker/build-push-action@v6
+      with:
+        push: ${{ github.event_name != 'pull_request' }}
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## [UNRELEASED] - Under development
+
+- Create Dockerfile to build Docker image with Modsecurity and CRS
+- Setup Github Workflow to build and publish the image
+
+## [1.0.0] - DATE_TODO
+
+- TODO
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM owasp/modsecurity-crs:4-nginx-alpine-202502070602
+
+USER root
+
+RUN apk update \
+ && apk add socat iproute2 net-tools iputils-ping bash \
+ && rm -rf /var/cache/apk/*

--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Modsecurity + CRS for HackInSDN
+
+[![ci-badge]][ci-link]
+
+## Description
+
+For now HackInSDN requires Socat and other tools to be installed in the docker
+image to expose service and configure networking.
+
+[ci-badge]: ../../actions/workflows/docker-image.yml/badge.svg
+[ci-link]: ../../actions/workflows/docker-image.yml


### PR DESCRIPTION
This PR configures Modsecurity+CRS docker image to be used in HackInSDN with required tools (Closes #1).

Also it setup Github Workflows to build and publish to Docker Hub (Closes #2).

In order to merge this PR, please setup `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` as secrets in this repository.

- [x] setup `DOCKERHUB_USERNAME`
- [x] setup `DOCKERHUB_TOKEN`